### PR TITLE
Tests: upgrade to .NET 6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,10 +10,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Setup .NET Core SDK 3.1.x
+      - name: Setup .NET SDK 6.0.x
         uses: actions/setup-dotnet@v1.7.2
         with:
-          dotnet-version: '3.1.x'
+          dotnet-version: '6.0.x'
       - name: Install dependencies
         run: dotnet restore
       - name: Build
@@ -31,10 +31,10 @@ jobs:
           submodules: recursive
           # needed because of commit-lint, see https://github.com/conventional-changelog/commitlint/issues/3376
           fetch-depth: 0
-      - name: Setup .NET SDK 5.0.x
+      - name: Setup .NET SDK 6.0.x
         uses: actions/setup-dotnet@v1.7.2
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
       - name: Install dependencies
         run: dotnet restore
       - name: Build
@@ -84,10 +84,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Setup .NET Core SDK 3.1.x
+      - name: Setup .NET SDK 6.0.x
         uses: actions/setup-dotnet@v1.7.2
         with:
-          dotnet-version: '3.1.x'
+          dotnet-version: '6.0.x'
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/NOnion.Tests/NOnion.Tests.csproj
+++ b/NOnion.Tests/NOnion.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
This commit upgrades test project and our CI to use .NET 6. There's no excuse to use .netcoreapp 3.1 anymore.

It's noteworthy to say that we will keep NOnion target platform on netstandard2.0 for the time being.

P.S:
My reason for this upgrade was mostly lack of native apple silicon support in .NET Core 3.1.